### PR TITLE
Update GoDaddy provider info

### DIFF
--- a/deploy.tofu
+++ b/deploy.tofu
@@ -10,8 +10,8 @@ terraform {
       version = "~> 5.0"
     }
     godaddy-dns = {
-      source  = "veksh/godaddy-dns"
-      version = "~> 0.3"
+      source  = "registry.terraform.io/veksh/godaddy-dns"
+      version = ">= 0.3.12"
     }
     github = {
       source  = "integrations/github"

--- a/modules/static_site/main.tofu
+++ b/modules/static_site/main.tofu
@@ -5,7 +5,8 @@ terraform {
       configuration_aliases = [aws.useast1]
     }
     godaddy-dns = {
-      source = "veksh/godaddy-dns"
+      source  = "registry.terraform.io/veksh/godaddy-dns"
+      version = ">= 0.3.12"
     }
   }
 }

--- a/modules/static_site/tests/basic/main.tf
+++ b/modules/static_site/tests/basic/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    godaddy-dns = {
+      source  = "registry.terraform.io/veksh/godaddy-dns"
+      version = ">= 0.3.12"
+    }
+  }
+}
+
+module "static_site" {
+  source = "../"
+
+  domain_name        = "www.example.com"
+  root_domain        = "example.com"
+  log_retention_days = 30
+
+  providers = {
+    aws         = aws
+    aws.useast1 = aws.useast1
+    godaddy-dns = godaddy-dns
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "useast1"
+  region = "us-east-1"
+}
+
+provider "godaddy-dns" {
+  api_key    = "dummy"
+  api_secret = "dummy"
+}

--- a/modules/static_site/tests/run.tftest.hcl
+++ b/modules/static_site/tests/run.tftest.hcl
@@ -1,0 +1,3 @@
+run "plan" {
+  command = plan
+}

--- a/modules/static_site/tests/run.tftest.hcl
+++ b/modules/static_site/tests/run.tftest.hcl
@@ -1,3 +1,3 @@
 run "plan" {
-  command = plan
+  command = "plan"
 }


### PR DESCRIPTION
## Summary
- specify provider source and version for `godaddy-dns`
- expand module test to declare provider requirements and mappings

## Testing
- `tofu init` *(passed)*
- `tofu test -test-directory=tests -no-color` *(fails: provider configuration not present)*

------
https://chatgpt.com/codex/tasks/task_e_684ddab800c48322a313b4277b55655e

## Summary by Sourcery

Update Terraform module to declare GoDaddy DNS and AWS provider configurations and expand integration tests with a basic plan run.

Enhancements:
- Specify GoDaddy DNS provider source and version in Terraform required_providers
- Pin AWS provider version to ~> 5.0 in module tests

Tests:
- Add basic Terraform module test with provider declarations and mappings
- Introduce run.tftest.hcl to execute a plan command as part of tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced new test configurations to validate the static site module with AWS and GoDaddy DNS providers, including multi-region support and DNS management.
  - Added a test run to execute Terraform plan commands for the module.
- **Chores**
  - Updated provider configuration to use a fully qualified source and added a minimum version constraint for the GoDaddy DNS provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->