### PR TITLE
Add monitoring tests and update provider

### DIFF
--- a/deploy.tofu
+++ b/deploy.tofu
@@ -10,8 +10,8 @@ terraform {
       version = "~> 5.0"
     }
     godaddy-dns = {
-      source  = "veksh/godaddy-dns"
-      version = "~> 0.3"
+      source  = "registry.terraform.io/veksh/godaddy-dns"
+      version = ">= 0.3.12"
     }
     github = {
       source  = "integrations/github"

--- a/modules/monitoring/tests/budget_limit.tftest.hcl
+++ b/modules/monitoring/tests/budget_limit.tftest.hcl
@@ -1,0 +1,17 @@
+run "plan" {
+  command = plan
+  module {
+    source = "../"
+  }
+  variables {
+    domain_name      = "test.example.com"
+    bucket_name      = "test-bucket"
+    distribution_id  = "TEST123"
+    budget_limit_gbp = 20
+    budget_email     = "alerts@example.com"
+  }
+  assert {
+    condition     = aws_budgets_budget.monthly_limit.limit_amount == 20
+    error_message = "Budget limit should be 20"
+  }
+}

--- a/modules/monitoring/tests/budget_limit.tftest.hcl
+++ b/modules/monitoring/tests/budget_limit.tftest.hcl
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 run "plan" {
   command = plan
   module {
@@ -11,7 +19,7 @@ run "plan" {
     budget_email     = "alerts@example.com"
   }
   assert {
-    condition     = aws_budgets_budget.monthly_limit.limit_amount == 20
+    condition     = testing.plan.resource_changes["aws_budgets_budget.monthly_limit"].change.after.limit_amount == 20
     error_message = "Budget limit should be 20"
   }
 }

--- a/modules/monitoring/tests/dashboard_name.tftest.hcl
+++ b/modules/monitoring/tests/dashboard_name.tftest.hcl
@@ -1,0 +1,17 @@
+run "plan" {
+  command = plan
+  module {
+    source = "../"
+  }
+  variables {
+    domain_name      = "demo.example.com"
+    bucket_name      = "demo-bucket"
+    distribution_id  = "DEMO123"
+    budget_limit_gbp = 5
+    budget_email     = "alerts@example.com"
+  }
+  assert {
+    condition     = aws_cloudwatch_dashboard.site.dashboard_name == "demo.example.com-visitors"
+    error_message = "Dashboard name mismatch"
+  }
+}

--- a/modules/monitoring/tests/dashboard_name.tftest.hcl
+++ b/modules/monitoring/tests/dashboard_name.tftest.hcl
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 run "plan" {
   command = plan
   module {
@@ -11,7 +19,7 @@ run "plan" {
     budget_email     = "alerts@example.com"
   }
   assert {
-    condition     = aws_cloudwatch_dashboard.site.dashboard_name == "demo.example.com-visitors"
+    condition     = testing.plan.resource_changes["aws_cloudwatch_dashboard.site"].change.after.dashboard_name == "demo.example.com-visitors"
     error_message = "Dashboard name mismatch"
   }
 }

--- a/modules/monitoring/tests/simple.tftest.hcl
+++ b/modules/monitoring/tests/simple.tftest.hcl
@@ -1,0 +1,13 @@
+run "default" {
+  command = plan
+  module {
+    source = "../"
+  }
+  variables {
+    domain_name      = "foo"
+    bucket_name      = "bar"
+    distribution_id  = "baz"
+    budget_limit_gbp = 10
+    budget_email     = "e@example.com"
+  }
+}

--- a/modules/monitoring/tests/simple.tftest.hcl
+++ b/modules/monitoring/tests/simple.tftest.hcl
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 run "default" {
   command = plan
   module {
@@ -9,5 +17,9 @@ run "default" {
     distribution_id  = "baz"
     budget_limit_gbp = 10
     budget_email     = "e@example.com"
+  }
+  assert {
+    condition     = testing.plan.resource_changes["aws_budgets_budget.monthly_limit"].change.after.time_unit == "MONTHLY"
+    error_message = "Budget time unit should be monthly"
   }
 }

--- a/modules/static_site/main.tofu
+++ b/modules/static_site/main.tofu
@@ -5,7 +5,7 @@ terraform {
       configuration_aliases = [aws.useast1]
     }
     godaddy-dns = {
-      source = "veksh/godaddy-dns"
+      source = "registry.terraform.io/veksh/godaddy-dns"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update the godaddy-dns provider declaration to use the Terraform registry
- align the static_site module with the same provider source
- provide example `tofu test` files for the monitoring module

## Testing
- `tofu init -backend=false` *(success)*
- `tofu test -test-directory=modules/monitoring/tests` *(fails: unknown variable)*

------
https://chatgpt.com/codex/tasks/task_e_684ddac6654083229fa2cb3d606a1175

## Summary by Sourcery

Update provider declarations to use Terraform registry sources for godaddy-dns and static_site modules and add tofu-based tests for the monitoring module.

New Features:
- Add tofu test suites for monitoring module with budget limit, dashboard name, and default configuration validations

Enhancements:
- Update godaddy-dns provider source to Terraform registry
- Align static_site module to use the same Terraform registry provider source

Tests:
- Add tofu test files for monitoring module covering budget limits, dashboard naming, and default setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Terraform provider source for GoDaddy DNS to use the fully qualified registry address and adjusted the version constraint.
- **Tests**
  - Added new automated tests for the monitoring module, including tests for budget limit, dashboard name formatting, and a basic plan scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->