### PR TITLE
Add AGENTS guide for OpenTofu deploy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 This repository manages a sample website using **OpenTofu**. The top-level deployment entrypoint is `deploy.tofu`. Reusable modules live under `modules/` (e.g., `modules/static_site`, `modules/deploy`, `modules/monitoring`). Module tests reside inside each module's `tests/` directory. Additional documentation is provided in `docs/`, including:
 
-- `docs/opentofu-hcl-syntax-guide.md` – HCL style, block structure, and formatting conventions.
-- `docs/opentofu-module-unit-testing-guide.md` – instructions for unit testing modules with the OpenTofu native framework.
+- [HCL Syntax Guide](docs/opentofu-hcl-syntax-guide.md) – HCL style, block structure, and formatting conventions.
+- [Module Unit-Testing Guide](docs/opentofu-module-unit-testing-guide.md) – instructions for unit testing modules with the OpenTofu native framework.
 
 ## Formatting and Validation
 
@@ -19,7 +19,7 @@ These commands ensure consistent style, validate syntax, and execute unit tests.
 
 ## Development Workflow
 
-Changes to `deploy.tofu` or any module should be tested with the OpenTofu native framework as described in `docs/opentofu-module-unit-testing-guide.md`. Follow the standard workflow of `tofu init`, `tofu plan`, and `tofu apply` (or CI equivalents) when updating infrastructure.
+Test any changes to `deploy.tofu` or its modules using the OpenTofu native framework as described in `docs/opentofu-module-unit-testing-guide.md`. Follow the standard workflow of `tofu init`, `tofu plan`, and `tofu apply` (or CI equivalents) when updating infrastructure.
 
 ## Commit Messages
 
@@ -29,5 +29,7 @@ Use concise, conventional titles such as:
 - `fix: correct bucket policy`
 
 Mention the affected module or script in the body if necessary.
+
+For more details, see the [Conventional Commits](https://www.conventionalcommits.org/) specification.
 
 For further background, consult the `docs/` directory before making significant changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Contributor Guide
+
+This repository manages a sample website using **OpenTofu**. The top-level deployment entrypoint is `deploy.tofu`. Reusable modules live under `modules/` (e.g., `modules/static_site`, `modules/deploy`, `modules/monitoring`). Module tests reside inside each module's `tests/` directory. Additional documentation is provided in `docs/`, including:
+
+- `docs/opentofu-hcl-syntax-guide.md` – HCL style, block structure, and formatting conventions.
+- `docs/opentofu-module-unit-testing-guide.md` – instructions for unit testing modules with the OpenTofu native framework.
+
+## Formatting and Validation
+
+Whenever modifying `.tofu` or `.tf` files, run:
+
+```bash
+tofu fmt -check
+tofu validate
+tofu test
+```
+
+These commands ensure consistent style, validate syntax, and execute unit tests. See the unit testing guide for details on setting up and running tests.
+
+## Development Workflow
+
+Changes to `deploy.tofu` or any module should be tested with the OpenTofu native framework as described in `docs/opentofu-module-unit-testing-guide.md`. Follow the standard workflow of `tofu init`, `tofu plan`, and `tofu apply` (or CI equivalents) when updating infrastructure.
+
+## Commit Messages
+
+Use concise, conventional titles such as:
+
+- `feat: add new monitoring alarms`
+- `fix: correct bucket policy`
+
+Mention the affected module or script in the body if necessary.
+
+For further background, consult the `docs/` directory before making significant changes.


### PR DESCRIPTION
## Summary
- add AGENTS.md outlining OpenTofu workflow, testing, and commit guidelines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e1bf80e648322a17b3c4b80ebdb59

## Summary by Sourcery

Documentation:
- Introduce AGENTS.md as a central contributor guide for OpenTofu deployment workflows, module testing, formatting, validation, and commit guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a contributor guide with instructions for working with the OpenTofu-based sample website infrastructure, including development workflow, code quality checks, and commit message guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->