### PR TITLE
Fix monitoring module and tests

### DIFF
--- a/modules/monitoring/main.tofu
+++ b/modules/monitoring/main.tofu
@@ -32,11 +32,6 @@ resource "aws_budgets_budget" "monthly_limit" {
   limit_amount = var.budget_limit_gbp
   limit_unit   = "GBP"
   time_unit    = "MONTHLY"
-
-  cost_filters = {
-    Service = ["AmazonS3", "Amazon CloudFront"]
-  }
-
   notification {
     comparison_operator        = "GREATER_THAN"
     threshold                  = 50
@@ -129,7 +124,7 @@ locals {
 }
 
 resource "aws_cloudwatch_dashboard" "site" {
-  dashboard_name = "${var.domain_name}-visitors"
+  dashboard_name = "${replace(var.domain_name, ".", "-")}-visitors"
   dashboard_body = local.dashboard_body
 }
 

--- a/modules/monitoring/tests/run.tftest.hcl
+++ b/modules/monitoring/tests/run.tftest.hcl
@@ -1,0 +1,67 @@
+mock_provider "aws" {}
+
+run "budget_notifications" {
+  command = plan
+
+  variables {
+    domain_name      = "example.com"
+    bucket_name      = "logs"
+    distribution_id  = "DIST123"
+    budget_limit_gbp = 20
+    budget_email     = "ops@example.com"
+  }
+
+  assert {
+    condition     = tonumber(aws_budgets_budget.monthly_limit.limit_amount) == 20
+    error_message = "Budget limit should be 20 GBP"
+  }
+
+  assert {
+    condition     = contains(flatten([for n in aws_budgets_budget.monthly_limit.notification : n.subscriber_email_addresses]), "ops@example.com")
+    error_message = "Subscriber email not set correctly"
+  }
+}
+
+run "alarms_use_inputs" {
+  command = plan
+
+  variables {
+    domain_name      = "example.com"
+    bucket_name      = "my-bucket"
+    distribution_id  = "ABC123"
+    budget_limit_gbp = 10
+    budget_email     = "ops@example.com"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.s3_requests_spike.dimensions.BucketName == "my-bucket"
+    error_message = "S3 alarm should use provided bucket name"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.cf_requests_spike.dimensions.DistributionId == "ABC123"
+    error_message = "CloudFront alarm should use provided distribution id"
+  }
+}
+
+run "dashboard_metric" {
+  command = plan
+
+  variables {
+    domain_name      = "monitor.example.com"
+    bucket_name      = "dummy"
+    distribution_id  = "XYZ987"
+    budget_limit_gbp = 1
+    budget_email     = "ops@example.com"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_dashboard.site.dashboard_name == "monitor-example-com-visitors"
+    error_message = "Dashboard name incorrect"
+  }
+
+  assert {
+    condition     = strcontains(aws_cloudwatch_dashboard.site.dashboard_body, "XYZ987")
+    error_message = "Dashboard body should reference distribution id"
+  }
+}


### PR DESCRIPTION
## Summary
- remove obsolete cost_filters from monitoring budget
- sanitize dashboard name to avoid dots
- update tests to use mock providers correctly

## Testing
- `tofu init -backend=false`
- `tofu test -no-color`

------
https://chatgpt.com/codex/tasks/task_e_684e1baa36888322947fb8d7fc865d8c

## Summary by Sourcery

Fix monitoring module by removing obsolete budget filters, sanitizing dashboard names, and updating tests to use mock providers and verify configuration inputs

Bug Fixes:
- Remove obsolete cost_filters from monitoring budget
- Sanitize CloudWatch dashboard names by replacing dots with hyphens

Tests:
- Switch tests to use mock AWS providers for isolation
- Update test assertions for budget limits, notifications, alarms, and dashboard naming logic