### PR TITLE
feat: add site_path variable

### DIFF
--- a/deploy.tofu
+++ b/deploy.tofu
@@ -73,6 +73,11 @@ variable "github_token" {
   default   = ""
 }
 
+variable "site_path" {
+  type    = string
+  default = "site"
+}
+
 variable "budget_limit_gbp" {
   description = "Monthly cost limit that triggers email alerts (GBP)"
   type        = number
@@ -120,6 +125,7 @@ module "deploy" {
   github_repo     = var.github_repo
   github_branch   = var.github_branch
   github_token    = var.github_token
+  site_path       = var.site_path
 }
 
 module "monitoring" {

--- a/modules/deploy/main.tofu
+++ b/modules/deploy/main.tofu
@@ -36,6 +36,11 @@ variable "github_token" {
   type = string
 }
 
+variable "site_path" {
+  type    = string
+  default = "site"
+}
+
 # Clone repo and sync content to S3 whenever commit changes
 data "external" "git_sync" {
   program = ["bash", "-c", <<EOT
@@ -58,7 +63,7 @@ resource "null_resource" "deploy" {
     command     = <<EOT
       set -e
       echo "Syncing site to S3..."
-      aws s3 sync $(pwd)/site s3://${var.bucket_name} --delete
+      aws s3 sync "${path.module}/${var.site_path}" s3://${var.bucket_name} --delete
       echo "Invalidating CloudFront cache..."
       aws cloudfront create-invalidation --distribution-id ${var.distribution_id} --paths "/*"
     EOT


### PR DESCRIPTION
## Summary
- introduce `site_path` var for deploy module
- allow customizing site path when syncing to S3

## Testing
- `tofu fmt -check -recursive`
- `tofu validate` *(fails: Missing required argument in static_site)*
- `tofu test`


------
https://chatgpt.com/codex/tasks/task_e_684e3c2b10e083228ce6c3b81df73e12

## Summary by Sourcery

Introduce an optional `site_path` variable to the deploy module to customize the target directory when syncing a static site to S3.

New Features:
- Add `site_path` input variable to the deploy module

Enhancements:
- Use `site_path` when performing S3 sync operations to allow custom subdirectory deployment

Documentation:
- Document the new `site_path` parameter in the deploy module interface