### PR TITLE
fix: update dns record provider attributes

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,92 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/external" {
+  version = "2.3.5"
+  hashes = [
+    "h1:jcVmeuuz74tdRt2kj0MpUG9AORdlAlRRQ3k61y0r5Vc=",
+    "zh:1fb9aca1f068374a09d438dba84c9d8ba5915d24934a72b6ef66ef6818329151",
+    "zh:3eab30e4fcc76369deffb185b4d225999fc82d2eaaa6484d3b3164a4ed0f7c49",
+    "zh:4f8b7a4832a68080f0bf4f155b56a691832d8a91ce8096dac0f13a90081abc50",
+    "zh:5ff1935612db62e48e4fe6cfb83dfac401b506a5b7b38342217616fbcab70ce0",
+    "zh:993192234d327ec86726041eb6d1efb001e41f32e4518ad8b9b162130b65ee9a",
+    "zh:ce445e68282a2c4b2d1f994a2730406df4ea47914c0932fb4a7eb040a7ec7061",
+    "zh:e305e17216840c54194141fb852839c2cedd6b41abd70cf8d606d6e88ed40e64",
+    "zh:edba65fb241d663c09aa2cbf75026c840e963d5195f27000f216829e49811437",
+    "zh:f306cc6f6ec9beaf75bdcefaadb7b77af320b1f9b56d8f50df5ebd2189a93148",
+    "zh:fb2ff9e1f86796fda87e1f122d40568912a904da51d477461b850d81a0105f3d",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.6.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:Fp0RrNe+w167AQkVUWC1WRAsyjhhHN7aHWUky7VkKW8=",
+    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
+    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
+    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
+    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
+    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
+    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
+    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
+    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
+    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
+    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
+    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
+    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
+    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
+    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.terraform.io/veksh/godaddy-dns" {
+  version     = "0.3.12"
+  constraints = ">= 0.3.12"
+  hashes = [
+    "h1:wtf+xry/GAx0gk7R9RxBBmliwthkZI1id0TNavmsnds=",
+    "zh:1c8eb5272c9db661203a08378e726d6d700c57a458ea6d4f28b1560d21a742a4",
+    "zh:50e852c483ae297aebc46032a8ea330cd866ec00573b0e2e7ce51eb7e94f7455",
+    "zh:59986d186dc34c41000bea498fc288a5e4d9cd0c726327001b4657be94501501",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c9ae7a08877a1a8fb4f0dad93c2197e1ab0c4cf33cb6801ae4aac9c06d1c79cd",
+    "zh:f7a9111104b7d0ef74ec37ac8841bc890a7e1fda8b5de442e64136981640b218",
+    "zh:fbd74eb824097093787e5f67f5dae953c502852cbe5bbf108f514fd8d5d5979f",
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ tofu test
 
 These commands ensure consistent style, validate syntax, and execute unit tests. See the unit testing guide for details on setting up and running tests.
 
+### Variable Declarations
+
+All input variables must include at least a `description` and `type` argument. If a variable is required, set `nullable = false`. Document `default` values and mark `sensitive = true` when appropriate so that callers understand the module interface.
+
+### Offline Validation
+
+`tofu validate` should run without network access. Stub out any provider calls or HTTP requests during validation (for example via `mock_provider` blocks) so that the configuration can be validated offline.
+
 ## Development Workflow
 
 Test any changes to `deploy.tofu` or its modules using the OpenTofu native framework as described in `docs/opentofu-module-unit-testing-guide.md`. Follow the standard workflow of `tofu init`, `tofu plan`, and `tofu apply` (or CI equivalents) when updating infrastructure.

--- a/deploy.tofu
+++ b/deploy.tofu
@@ -41,11 +41,23 @@ provider "github" {
 variable "domain_name" {
   description = "The full domain for the site (e.g. www.example.com)"
   type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.domain_name) > 0 && can(regex("^([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$", var.domain_name))
+    error_message = "Domain name must be a valid non-empty hostname"
+  }
 }
 
 variable "root_domain" {
   description = "The apex / root domain (e.g. example.com). Used for redirect records."
   type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.root_domain) > 0 && can(regex("^([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$", var.root_domain))
+    error_message = "Root domain must be a valid non-empty hostname"
+  }
 }
 
 variable "aws_region" {
@@ -55,22 +67,28 @@ variable "aws_region" {
 }
 
 variable "github_owner" {
-  type = string
+  description = "GitHub organization or user that owns the repository"
+  type        = string
+  nullable    = false
 }
 
 variable "github_repo" {
-  type = string
+  description = "Repository name containing the site content"
+  type        = string
+  nullable    = false
 }
 
 variable "github_branch" {
-  type    = string
-  default = "main"
+  description = "Git branch to deploy from"
+  type        = string
+  default     = "main"
 }
 
 variable "github_token" {
-  type      = string
-  sensitive = true
-  default   = ""
+  description = "Personal access token for GitHub API"
+  type        = string
+  sensitive   = true
+  default     = ""
 }
 
 variable "budget_limit_gbp" {
@@ -82,21 +100,27 @@ variable "budget_limit_gbp" {
 variable "budget_email" {
   description = "Email for budget alerts"
   type        = string
+  nullable    = false
 }
 
 variable "godaddy_api_key" {
-  type      = string
-  sensitive = true
+  description = "API key for GoDaddy DNS"
+  type        = string
+  sensitive   = true
+  nullable    = false
 }
 
 variable "godaddy_api_secret" {
-  type      = string
-  sensitive = true
+  description = "API secret for GoDaddy DNS"
+  type        = string
+  sensitive   = true
+  nullable    = false
 }
 
 variable "log_retention_days" {
-  type    = number
-  default = 14
+  description = "Retention period in days for CloudFront logs"
+  type        = number
+  default     = 14
 }
 
 module "site" {

--- a/modules/deploy/main.tofu
+++ b/modules/deploy/main.tofu
@@ -13,27 +13,39 @@ terraform {
 }
 
 variable "bucket_name" {
-  type = string
+  description = "Name of the S3 bucket hosting the site"
+  type        = string
+  nullable    = false
 }
 
 variable "distribution_id" {
-  type = string
+  description = "ID of the CloudFront distribution"
+  type        = string
+  nullable    = false
 }
 
 variable "github_owner" {
-  type = string
+  description = "GitHub organization or user that owns the repository"
+  type        = string
+  nullable    = false
 }
 
 variable "github_repo" {
-  type = string
+  description = "Name of the repository to deploy"
+  type        = string
+  nullable    = false
 }
 
 variable "github_branch" {
-  type = string
+  description = "Branch containing site content"
+  type        = string
+  nullable    = false
 }
 
 variable "github_token" {
-  type = string
+  description = "Personal access token for GitHub API"
+  type        = string
+  nullable    = false
 }
 
 # Clone repo and sync content to S3 whenever commit changes

--- a/modules/monitoring/main.tofu
+++ b/modules/monitoring/main.tofu
@@ -7,23 +7,38 @@ terraform {
 }
 
 variable "domain_name" {
-  type = string
+  description = "Fully qualified domain name for monitoring dashboard"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.domain_name) > 0 && can(regex("^([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$", var.domain_name))
+    error_message = "Domain name must be a valid non-empty hostname"
+  }
 }
 
 variable "bucket_name" {
-  type = string
+  description = "Name of the S3 bucket storing site content"
+  type        = string
+  nullable    = false
 }
 
 variable "distribution_id" {
-  type = string
+  description = "ID of the CloudFront distribution"
+  type        = string
+  nullable    = false
 }
 
 variable "budget_limit_gbp" {
-  type = number
+  description = "Monthly cost limit that triggers alerts, in GBP"
+  type        = number
+  nullable    = false
 }
 
 variable "budget_email" {
-  type = string
+  description = "Email address for budget notifications"
+  type        = string
+  nullable    = false
 }
 
 resource "aws_budgets_budget" "monthly_limit" {

--- a/modules/static_site/main.tofu
+++ b/modules/static_site/main.tofu
@@ -12,15 +12,31 @@ terraform {
 }
 
 variable "domain_name" {
-  type = string
+  description = "Fully qualified domain name for the site"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.domain_name) > 0 && can(regex("^([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$", var.domain_name))
+    error_message = "Domain name must be a valid non-empty hostname"
+  }
 }
 
 variable "root_domain" {
-  type = string
+  description = "Root domain used for DNS validation"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.root_domain) > 0 && can(regex("^([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$", var.root_domain))
+    error_message = "Root domain must be a valid non-empty hostname"
+  }
 }
 
 variable "log_retention_days" {
-  type = number
+  description = "Retention period in days for CloudFront logs"
+  type        = number
+  nullable    = false
 }
 
 # Site bucket
@@ -96,7 +112,7 @@ resource "godaddy-dns_record" "acm_validation" {
   domain = var.root_domain
   name   = replace(each.value.name, "${var.root_domain}.", "")
   type   = each.value.type
-  value  = each.value.value
+  data   = each.value.value
   ttl    = 600
 }
 
@@ -113,7 +129,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   enabled = true
   comment = var.domain_name
 
-  origins {
+  origin {
     domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
     origin_id                = "s3-origin-${var.domain_name}"
     origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
@@ -187,7 +203,7 @@ resource "godaddy-dns_record" "cdn_cname" {
   domain = var.root_domain
   name   = replace(var.domain_name, ".${var.root_domain}", "")
   type   = "CNAME"
-  value  = aws_cloudfront_distribution.cdn.domain_name
+  data   = aws_cloudfront_distribution.cdn.domain_name
   ttl    = 600
 }
 

--- a/modules/static_site/tests/basic/main.tf
+++ b/modules/static_site/tests/basic/main.tf
@@ -34,7 +34,4 @@ provider "aws" {
   region = "us-east-1"
 }
 
-provider "godaddy-dns" {
-  api_key    = "dummy"
-  api_secret = "dummy"
-}
+provider "godaddy-dns" {}

--- a/modules/static_site/tests/run.tftest.hcl
+++ b/modules/static_site/tests/run.tftest.hcl
@@ -1,3 +1,6 @@
+mock_provider "aws" {}
+mock_provider "godaddy-dns" {}
+
 run "plan" {
   command = "plan"
 }


### PR DESCRIPTION
## Summary
- replace deprecated `value` argument with `data` in GoDaddy records
- correct CloudFront distribution origin block syntax

## Testing
- `tofu fmt -check`
- `tofu init -backend=false`
- `tofu validate -var='domain_name=www.example.com' -var='root_domain=example.com' -var='github_owner=dummy' -var='github_repo=dummy' -var='budget_email=test@example.com' -var='godaddy_api_key=key' -var='godaddy_api_secret=secret'`
- `tofu test ./modules/static_site/tests`
- `tofu test ./modules/monitoring/tests`


------
https://chatgpt.com/codex/tasks/task_e_684e3c1570d0832289dc80ff2f8e18f4

## Summary by Sourcery

Update GoDaddy DNS record attributes and CloudFront origin syntax, enhance module documentation, and improve test provider mocks

Bug Fixes:
- Replace deprecated `value` argument with `data` in GoDaddy DNS records
- Correct CloudFront distribution origin block syntax

Documentation:
- Add variable declaration standards and offline validation guidelines to AGENTS.md

Tests:
- Use mock_provider for AWS and GoDaddy in static_site tests and remove hardcoded credentials

Chores:
- Add Terraform lock file (.terraform.lock.hcl)