### PR TITLE
Add mock providers to tests

### DIFF
--- a/modules/deploy/tests/run.tftest.hcl
+++ b/modules/deploy/tests/run.tftest.hcl
@@ -1,0 +1,28 @@
+mock_provider "aws" {}
+mock_provider "external" {}
+mock_provider "null" {}
+
+override_resource null_resource.deploy {
+  values = {
+    triggers = {
+      commit = "deadbeef"
+    }
+  }
+}
+
+run "plan" {
+  command = plan
+
+  variables {
+    bucket_name     = "dummy-bucket"
+    distribution_id = "DIST123"
+    github_owner    = "example"
+    github_repo     = "repo"
+    github_branch   = "main"
+    github_token    = "dummy"
+  }
+
+  expect_failures = [
+    data.external.git_sync
+  ]
+}

--- a/modules/monitoring/tests/run.tftest.hcl
+++ b/modules/monitoring/tests/run.tftest.hcl
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "us-east-1"
-}
-
 mock_provider "aws" {}
 
 run "budget_notifications" {


### PR DESCRIPTION
## Summary
- update monitoring tests for offline provider mocking
- add offline tests for deploy module

## Testing
- `tofu validate`
- `tofu test`

------
https://chatgpt.com/codex/tasks/task_e_684e4e2b6cc88322a53feb6c34d0fa82

## Summary by Sourcery

Enable offline testing by replacing real providers with mock providers in monitoring tests and adding offline deploy module tests.

Tests:
- Replace AWS provider with mock_provider in monitoring tests
- Add deploy tests with mock_provider for AWS, external, and null along with variable-driven plan run and expected failures for external data source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added a new test configuration for deployment modules with mock providers and expected failure handling for external data sources.
	- Updated monitoring module tests to use a mock AWS provider, removing explicit region configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->