### PR TITLE
docs: clarify website ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This repository contains the configuration for **my** static website deployment 
 The `modules/deploy` script automates publishing site content:
 
 1. It clones the specified GitHub repository and extracts the latest commit ID.
-2. When the commit changes, it syncs the local `site` directory to the S3 bucket created by the stack.
-3. After uploading, it invalidates the CloudFront distribution so that visitors receive the newest files.
-4. A GitHub Actions workflow (coming soon) will automatically run this script whenever new commits are pushed.
+2. The contents of the cloned repository are placed in the local `site` directory.
+3. When the commit changes, it syncs the `site` directory to the S3 bucket created by the stack.
+4. After uploading, it invalidates the CloudFront distribution so that visitors receive the newest files.
+5. A GitHub Actions workflow (coming soon) will automatically run this script whenever new commits are pushed.
 
 See [docs/deploy.md](docs/deploy.md) for detailed configuration steps and options.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# df12 OpenTofu Site
+
+This repository contains the configuration for a static website deployment using [OpenTofu](https://opentofu.org). Infrastructure components are defined in modules under `modules/`.
+
+## Deployment Overview
+
+The `modules/deploy` script automates publishing site content:
+
+1. It clones the specified GitHub repository and extracts the latest commit ID.
+2. When the commit changes, it syncs the local `site` directory to the S3 bucket created by the stack.
+3. After uploading, it invalidates the CloudFront distribution so that visitors receive the newest files.
+
+See [docs/deploy.md](docs/deploy.md) for detailed configuration steps and options.
+
+This project is released under the [GNU Affero General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # df12 OpenTofu Site
 
-This repository contains the configuration for a static website deployment using [OpenTofu](https://opentofu.org). Infrastructure components are defined in modules under `modules/`.
+This repository contains the configuration for **my** static website deployment using [OpenTofu](https://opentofu.org). It is not meant as a generic template. Infrastructure components are defined in modules under `modules/`.
 
 ## Deployment Overview
 
@@ -9,6 +9,7 @@ The `modules/deploy` script automates publishing site content:
 1. It clones the specified GitHub repository and extracts the latest commit ID.
 2. When the commit changes, it syncs the local `site` directory to the S3 bucket created by the stack.
 3. After uploading, it invalidates the CloudFront distribution so that visitors receive the newest files.
+4. A GitHub Actions workflow (coming soon) will automatically run this script whenever new commits are pushed.
 
 See [docs/deploy.md](docs/deploy.md) for detailed configuration steps and options.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,17 +1,21 @@
 # Deploying the Static Site with OpenTofu
 
-This guide explains how to use the OpenTofu configuration in this repository to publish a static website. The process uses AWS S3 for storage, CloudFront for CDN, and a GitHub repository as the source of content.
+This guide explains how to use the OpenTofu configuration in this repository to publish **your** website. It is tailored to this project and not meant as a one-size-fits-all example. The process uses AWS S3 for storage, CloudFront for CDN, and a GitHub repository as the source of content.
 
 ## Prerequisites
 
-- [OpenTofu](https://opentofu.org/) installed on your local machine.
-- [AWS CLI](https://aws.amazon.com/cli/) configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
+- [OpenTofu](https://opentofu.org/) **v1.6** or newer installed on your local machine.
+- [AWS CLI](https://aws.amazon.com/cli/) **v2.0** or newer configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
 - A personal access token for the GitHub repository containing your site files.
 
 ## Configuration
 
-1. **Clone this repository** and change into its directory.
-2. Edit `variables.tofu` or create a `terraform.tfvars` file to provide values for the required variables:
+1. **Clone this repository** and change into its directory:
+   ```bash
+   git clone git@github.com:leynos/df12-www.git
+   cd df12-www
+   ```
+2. Create a `terraform.tfvars` file (or edit `variables.tf`) to provide values for the required variables (see `terraform.tfvars.example` for guidance):
    - `domain_name` – fully qualified domain (e.g. `www.example.com`).
    - `root_domain` – apex domain (e.g. `example.com`).
    - `github_owner` and `github_repo` – location of the site source.
@@ -37,7 +41,7 @@ This guide explains how to use the OpenTofu configuration in this repository to 
    tofu apply
    ```
 
-After the first apply, the `modules/deploy` script tracks commits in the specified GitHub repository. Each time the commit hash changes, it synchronizes the `site` directory with the S3 bucket and invalidates the CloudFront cache so that new content becomes available immediately.
+After the first apply, a forthcoming GitHub Actions workflow will monitor the repository for new commits. When it detects a change, it runs the `modules/deploy` script which syncs the `site` directory to the S3 bucket and invalidates the CloudFront cache so visitors see the updated content immediately.
 
 ## Updating Content
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,58 @@
+# Deploying the Static Site with OpenTofu
+
+This guide explains how to use the OpenTofu configuration in this repository to publish a static website. The process uses AWS S3 for storage, CloudFront for CDN, and a GitHub repository as the source of content.
+
+## Prerequisites
+
+- [OpenTofu](https://opentofu.org/) installed on your local machine.
+- [AWS CLI](https://aws.amazon.com/cli/) configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
+- A personal access token for the GitHub repository containing your site files.
+
+## Configuration
+
+1. **Clone this repository** and change into its directory.
+2. Edit `variables.tofu` or create a `terraform.tfvars` file to provide values for the required variables:
+   - `domain_name` – fully qualified domain (e.g. `www.example.com`).
+   - `root_domain` – apex domain (e.g. `example.com`).
+   - `github_owner` and `github_repo` – location of the site source.
+   - `github_token` – GitHub PAT used by the `deploy` module.
+   - `budget_email` – address for cost alerts.
+3. Optionally adjust defaults such as the AWS region or log retention days.
+
+## Running the Deployment
+
+1. Initialize the working directory:
+
+   ```bash
+   tofu init
+   ```
+2. Review the planned actions:
+
+   ```bash
+   tofu plan
+   ```
+3. Apply the configuration to create the infrastructure:
+
+   ```bash
+   tofu apply
+   ```
+
+After the first apply, the `modules/deploy` script tracks commits in the specified GitHub repository. Each time the commit hash changes, it synchronizes the `site` directory with the S3 bucket and invalidates the CloudFront cache so that new content becomes available immediately.
+
+## Updating Content
+
+Push changes to the configured branch of your GitHub repository. The next run of the deployment will detect the new commit and publish the updated site automatically. You can trigger the sync manually by running `tofu apply` again.
+
+## Testing and Validation
+
+The repository includes unit tests under each module's `tests/` directory. Run `tofu test` to execute them. Formatting and syntax can be verified with `tofu fmt -check` and `tofu validate`.
+
+## Cleanup
+
+To remove all resources created by this configuration, run:
+
+```bash
+tofu destroy
+```
+
+Ensure you no longer need the S3 bucket contents or any CloudFront distributions before destroying.

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,11 @@
+domain_name      = "www.example.com"
+root_domain      = "example.com"
+aws_region       = "eu-west-2"
+github_owner     = "example"
+github_repo      = "site"
+github_branch    = "main"
+github_token     = "ghp_your_pat_here"
+budget_limit_gbp = 5
+budget_email     = "billing@example.com"
+godaddy_api_key  = "key"
+godaddy_api_secret = "secret"


### PR DESCRIPTION
## Summary
- document how to deploy the site with OpenTofu
- add deployment overview and license note to README
- clarify that the site configuration is for your website, not an example

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ecb5046c4832283354f0793593e92

## Summary by Sourcery

Provide detailed deployment documentation for OpenTofu-based static site deployment, clarify repository purpose as a personal site configuration, and include license information.

Documentation:
- Add docs/deploy.md with step-by-step instructions for configuring and deploying the static site using OpenTofu.
- Update README with a deployment overview and explicit note that this repository is for a personal site configuration.
- Include GNU AGPLv3 license information in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive README describing the project, deployment process, and licensing.
  - Introduced a detailed deployment guide outlining prerequisites, configuration steps, deployment commands, content updates, testing, and cleanup procedures.
  - Included an example configuration file template to assist with environment-specific deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->