### PR TITLE
chore: apply review feedback

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,9 +4,9 @@ This guide explains how to use the OpenTofu configuration in this repository to 
 
 ## Prerequisites
 
- - [OpenTofu](https://opentofu.org/) **v1.6** or newer installed locally.
- - [AWS CLI](https://aws.amazon.com/cli/) **v2.0** or newer configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
- - A personal access token for the GitHub repository containing the site files. The deployment module uses a temporary Git configuration include to inject an HTTP Authorization header during `git clone`, avoiding exposure of credentials in process arguments.
+- [OpenTofu](https://opentofu.org/) **v1.6** or newer installed locally.
+- [AWS CLI](https://aws.amazon.com/cli/) **v2.0** or newer configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
+- A personal access token for the GitHub repository containing the site files. The deployment module uses a temporary Git configuration include to inject an HTTP Authorization header during `git clone`, avoiding exposure of credentials in process arguments.
 
 ## Configuration
 
@@ -21,7 +21,7 @@ This guide explains how to use the OpenTofu configuration in this repository to 
    - `github_owner` and `github_repo` – location of the site source.
    - `github_token` – GitHub PAT used by the `deploy` module for authenticated cloning.
    - `budget_email` – address for cost alerts.
-   - `project_name` – identifier used in resource tags (defaults to `df12-www`).
+   - `project_name` — identifier used in resource tags (defaults to `df12-www`).
 3. Optionally adjust defaults such as the AWS region or log retention days.
 
 ## Running the Deployment

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,9 +4,9 @@ This guide explains how to use the OpenTofu configuration in this repository to 
 
 ## Prerequisites
 
-- [OpenTofu](https://opentofu.org/) **v1.6** or newer installed locally.
-- [AWS CLI](https://aws.amazon.com/cli/) **v2.0** or newer configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
-- A personal access token for the GitHub repository containing the site files. The deployment module uses a temporary Git configuration include to inject an HTTP Authorization header during `git clone`, avoiding exposure of credentials in process arguments.
+ - [OpenTofu](https://opentofu.org/) **v1.6** or newer installed locally.
+ - [AWS CLI](https://aws.amazon.com/cli/) **v2.0** or newer configured with credentials that can create S3 buckets, CloudFront distributions and other resources.
+ - A personal access token for the GitHub repository containing the site files. The deployment module uses a temporary Git configuration include to inject an HTTP Authorization header during `git clone`, avoiding exposure of credentials in process arguments.
 
 ## Configuration
 
@@ -21,6 +21,7 @@ This guide explains how to use the OpenTofu configuration in this repository to 
    - `github_owner` and `github_repo` – location of the site source.
    - `github_token` – GitHub PAT used by the `deploy` module for authenticated cloning.
    - `budget_email` – address for cost alerts.
+   - `project_name` – identifier used in resource tags.
 3. Optionally adjust defaults such as the AWS region or log retention days.
 
 ## Running the Deployment

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -21,7 +21,7 @@ This guide explains how to use the OpenTofu configuration in this repository to 
    - `github_owner` and `github_repo` – location of the site source.
    - `github_token` – GitHub PAT used by the `deploy` module for authenticated cloning.
    - `budget_email` – address for cost alerts.
-   - `project_name` – identifier used in resource tags.
+   - `project_name` – identifier used in resource tags (defaults to `df12-www`).
 3. Optionally adjust defaults such as the AWS region or log retention days.
 
 ## Running the Deployment

--- a/modules/static_site/terraform.tofu
+++ b/modules/static_site/terraform.tofu
@@ -8,7 +8,7 @@ terraform {
     }
     godaddy-dns = {
       source  = "registry.terraform.io/veksh/godaddy-dns"
-      version = ">= 0.3.12"
+      version = "~> 0.3.12"
     }
   }
 }

--- a/modules/static_site/tests/run.tftest.hcl
+++ b/modules/static_site/tests/run.tftest.hcl
@@ -26,4 +26,9 @@ run "plan" {
     root_domain        = "example.com"
     log_retention_days = 1
   }
+
+  assert {
+    condition     = length(tostring(module.static_site.bucket_name)) > 0
+    error_message = "bucket_name output must be non-empty"
+  }
 }

--- a/modules/static_site/tests/run.tftest.hcl
+++ b/modules/static_site/tests/run.tftest.hcl
@@ -28,7 +28,7 @@ run "plan" {
   }
 
   assert {
-    condition     = length(tostring(module.static_site.bucket_name)) > 0
+    condition     = output.bucket_name != ""
     error_message = "bucket_name output must be non-empty"
   }
 }

--- a/providers.tofu
+++ b/providers.tofu
@@ -1,5 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy   = "terraform"
+      Environment = var.environment
+      Project     = var.project_name
+    }
+  }
 }
 
 provider "aws" {

--- a/providers.tofu
+++ b/providers.tofu
@@ -3,7 +3,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      ManagedBy   = "terraform"
+      ManagedBy   = "OpenTofu"
       Environment = var.environment
       Project     = var.project_name
     }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -13,6 +13,9 @@ aws_region = "eu-west-2"
 # Deployment environment
 environment = "dev"
 
+# Project identifier used for tagging resources
+project_name = "df12-www"
+
 # GitHub organization or user that owns the repository
 github_owner = "example"
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -13,7 +13,7 @@ aws_region = "eu-west-2"
 # Deployment environment
 environment = "dev"
 
-# Project identifier used for tagging resources
+# Project identifier used for tagging resources (defaults to "df12-www")
 project_name = "df12-www"
 
 # GitHub organization or user that owns the repository

--- a/variables.tofu
+++ b/variables.tofu
@@ -44,8 +44,8 @@ variable "project_name" {
   nullable    = false
 
   validation {
-    condition     = length(var.project_name) > 0 && can(regex("^[a-zA-Z0-9-]+$", var.project_name))
-    error_message = "Project name must be a non-empty alphanumeric or hyphenated string"
+    condition     = length(trimspace(var.project_name)) > 0 && can(regex("^[a-z0-9-]+$", var.project_name))
+    error_message = "Project name must be a non-empty lowercase alphanumeric or hyphenated slug"
   }
 }
 

--- a/variables.tofu
+++ b/variables.tofu
@@ -37,6 +37,17 @@ variable "environment" {
   }
 }
 
+variable "project_name" {
+  description = "Project name for tagging resources"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.project_name) > 0 && can(regex("^[a-zA-Z0-9-]+$", var.project_name))
+    error_message = "Project name must be a non-empty alphanumeric or hyphenated string"
+  }
+}
+
 variable "github_owner" {
   description = "GitHub organization or user that owns the repository"
   type        = string

--- a/variables.tofu
+++ b/variables.tofu
@@ -40,6 +40,7 @@ variable "environment" {
 variable "project_name" {
   description = "Project name for tagging resources"
   type        = string
+  default     = "df12-www"
   nullable    = false
 
   validation {


### PR DESCRIPTION
## Summary
- pin godaddy provider minor version
- add bucket name assertion for static site test
- introduce project name tag and provider default tags
- document project name variable and normalize docs list formatting

## Testing
- `tofu fmt -check`
- `tofu validate`
- `tofu test`


------
https://chatgpt.com/codex/tasks/task_e_689f46436ed48322bfcd715185fb1e1c

## Summary by Sourcery

Apply review feedback by pinning the GoDaddy provider version, introducing project_name tagging, adding a bucket_name assertion in static site tests, and updating documentation formatting

Enhancements:
- Pin the GoDaddy provider to a specific minor version
- Introduce a project_name tag and apply default tags in providers

Documentation:
- Document the project_name variable in the deployment guide
- Normalize bullet list formatting in the deployment documentation

Tests:
- Add an assertion in the static_site test to ensure the bucket_name output is non-empty